### PR TITLE
Add endpoints for partials subsitutions in XLIFF

### DIFF
--- a/backend/alembic/versions/15355f38c714_enable_n_grams_extension.py
+++ b/backend/alembic/versions/15355f38c714_enable_n_grams_extension.py
@@ -1,0 +1,29 @@
+"""Enable n-grams extension
+
+Revision ID: 15355f38c714
+Revises: b3e764c93fac
+Create Date: 2024-07-16 22:14:21.734202
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# pylint: disable=E1101
+
+# revision identifiers, used by Alembic.
+revision: str = '15355f38c714'
+down_revision: Union[str, None] = 'd78c74ab226b'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute('CREATE EXTENSION pg_trgm')
+    op.execute('CREATE INDEX trgm_tmx_src_idx ON tmx_record USING gist (source gist_trgm_ops)')
+
+def downgrade() -> None:
+    op.execute('DROP INDEX trgm_tmx_src_idx')
+    op.execute('DROP EXTENSION pg_trgm')

--- a/backend/alembic/versions/6d107741a92e_add_glossary.py
+++ b/backend/alembic/versions/6d107741a92e_add_glossary.py
@@ -1,4 +1,4 @@
-"""add glossary
+"""Add glossary
 
 Revision ID: 6d107741a92e
 Revises: b3e764c93fac

--- a/backend/alembic/versions/d78c74ab226b_add_links_between_xliff_and_tmx.py
+++ b/backend/alembic/versions/d78c74ab226b_add_links_between_xliff_and_tmx.py
@@ -1,0 +1,33 @@
+"""Add links between xliff and tmx
+
+Revision ID: d78c74ab226b
+Revises: b3e764c93fac
+Create Date: 2024-07-17 01:03:39.274777
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# pylint: disable=E1101
+
+# revision identifiers, used by Alembic.
+revision: str = 'd78c74ab226b'
+down_revision: Union[str, None] = 'b3e764c93fac'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table('xliff_record_to_tmx',
+        sa.Column('xliff_id', sa.Integer(), nullable=False),
+        sa.Column('tmx_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['tmx_id'], ['tmx_document.id'], ),
+        sa.ForeignKeyConstraint(['xliff_id'], ['xliff_document.id'], )
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('xliff_record_to_tmx')

--- a/backend/alembic/versions/d78c74ab226b_add_links_between_xliff_and_tmx.py
+++ b/backend/alembic/versions/d78c74ab226b_add_links_between_xliff_and_tmx.py
@@ -15,7 +15,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = 'd78c74ab226b'
-down_revision: Union[str, None] = 'b3e764c93fac'
+down_revision: Union[str, None] = '6d107741a92e'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -71,6 +71,12 @@ class XliffRecordUpdate(BaseModel):
     target: str
 
 
+class XliffSubstitution(BaseModel):
+    source: str
+    target: str
+    similarity: float
+
+
 class MachineTranslationSettings(BaseModel):
     # Yandex only for now
     # source_language: str

--- a/backend/app/routers/xliff.py
+++ b/backend/app/routers/xliff.py
@@ -209,6 +209,12 @@ def process_xliff(
         )
 
     doc.processing_status = models.DocumentStatus.PENDING.value
+    tmxs = (
+        db.query(schema.TmxDocument)
+        .filter(schema.TmxDocument.id.in_(settings.tmx_file_ids))
+        .all()
+    )
+    doc.tmxs = tmxs
     db.commit()
 
     task_config = {

--- a/backend/app/routers/xliff.py
+++ b/backend/app/routers/xliff.py
@@ -136,7 +136,7 @@ def get_segment_substitutions(
         select(schema.TmxRecord.source, schema.TmxRecord.target, similarity_func)
         .filter(
             schema.TmxRecord.source.op("%")(original_segment.source),
-            schema.TmxRecord.id.in_(tmx_ids),
+            schema.TmxRecord.document_id.in_(tmx_ids),
         )
         .order_by(similarity_func.desc())
         .limit(10),

--- a/backend/app/schema.py
+++ b/backend/app/schema.py
@@ -1,13 +1,21 @@
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import ForeignKey
+from sqlalchemy import Column, ForeignKey, Table
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db import Base
 
 if TYPE_CHECKING:
     from app.glossary.models import GlossaryDocument
+
+
+xliff_to_tmx_link = Table(
+    "xliff_record_to_tmx",
+    Base.metadata,
+    Column("xliff_id", ForeignKey("xliff_document.id"), nullable=False),
+    Column("tmx_id", ForeignKey("tmx_document.id"), nullable=False),
+)
 
 
 class TmxDocument(Base):
@@ -21,6 +29,9 @@ class TmxDocument(Base):
         back_populates="document", cascade="all, delete-orphan", order_by="TmxRecord.id"
     )
     user: Mapped["User"] = relationship(back_populates="tmxs")
+    xliffs: Mapped[list["XliffDocument"]] = relationship(
+        secondary=xliff_to_tmx_link, back_populates="tmxs"
+    )
 
 
 class TmxRecord(Base):
@@ -52,6 +63,9 @@ class XliffDocument(Base):
         order_by="XliffRecord.id",
     )
     user: Mapped["User"] = relationship(back_populates="xliffs")
+    tmxs: Mapped[list["TmxDocument"]] = relationship(
+        secondary=xliff_to_tmx_link, back_populates="xliffs"
+    )
 
 
 class XliffRecord(Base):

--- a/backend/app/schema.py
+++ b/backend/app/schema.py
@@ -30,7 +30,7 @@ class TmxDocument(Base):
     )
     user: Mapped["User"] = relationship(back_populates="tmxs")
     xliffs: Mapped[list["XliffDocument"]] = relationship(
-        secondary=xliff_to_tmx_link, back_populates="tmxs"
+        secondary=xliff_to_tmx_link, back_populates="tmxs", order_by="XliffDocument.id"
     )
 
 
@@ -64,7 +64,7 @@ class XliffDocument(Base):
     )
     user: Mapped["User"] = relationship(back_populates="xliffs")
     tmxs: Mapped[list["TmxDocument"]] = relationship(
-        secondary=xliff_to_tmx_link, back_populates="xliffs"
+        secondary=xliff_to_tmx_link, back_populates="xliffs", order_by="TmxDocument.id"
     )
 
 


### PR DESCRIPTION
Added usage of `pg_trgm` to substitute segments with non-exact match.