### PR TITLE
Add unified created_by field for glossary and records

### DIFF
--- a/backend/alembic/versions/483194aa72bd_replace_author_column.py
+++ b/backend/alembic/versions/483194aa72bd_replace_author_column.py
@@ -1,0 +1,60 @@
+"""Replace author column
+
+Revision ID: 483194aa72bd
+Revises: 18b485855e40
+Create Date: 2024-09-12 01:21:43.226155
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# pylint: disable=E1101
+
+# revision identifiers, used by Alembic.
+revision: str = '483194aa72bd'
+down_revision: Union[str, None] = '18b485855e40'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # update glossary record table
+    op.add_column('glossary_record', sa.Column('created_by', sa.Integer()))
+    op.create_foreign_key(None, 'glossary_record', 'user', ['created_by'], ['id'])
+    op.execute(
+        sa.update(sa.table("glossary_record", sa.Column("created_by"))).values(
+            created_by=1  # first administrator account
+        )
+    )
+    op.alter_column('glossary_record', 'created_by', nullable=False)
+    op.drop_column('glossary_record', 'author')
+
+    # update glossary table
+    op.alter_column('glossary', 'user_id', new_column_name='created_by')
+    op.drop_constraint('glossary_user_id_fkey', "glossary", type_="foreignkey")
+    op.create_foreign_key(
+        "glossary_created_by_fkey",
+        "glossary",
+        "user",
+        ["created_by"],
+        ["id"],
+    )
+
+
+def downgrade() -> None:
+    op.alter_column('glossary', 'created_by', new_column_name='user_id')
+    op.drop_constraint('glossary_created_by_fkey', "glossary", type_="foreignkey")
+    op.create_foreign_key(
+        "glossary_user_id_fkey",
+        "glossary",
+        "user",
+        ["user_id"],
+        ["id"],
+    )
+
+    op.add_column('glossary_record', sa.Column('author', sa.String(), autoincrement=False, nullable=True))
+    op.drop_constraint('glossary_record_created_by_fkey', 'glossary_record', type_='foreignkey')
+    op.drop_column('glossary_record', 'created_by')

--- a/backend/app/glossary/controllers.py
+++ b/backend/app/glossary/controllers.py
@@ -73,11 +73,11 @@ def update_glossary_record_controller(
 
 
 def create_glossary_record_controller(
-    glossary_id: int, record: GlossaryRecordCreate, db: Session
+    user_id: int, glossary_id: int, record: GlossaryRecordCreate, db: Session
 ):
     try:
         return GlossaryQuery(db).create_glossary_record(
-            glossary_id=glossary_id, record=record
+            user_id=user_id, glossary_id=glossary_id, record=record
         )
     except NotFoundGlossaryExc:
         return None

--- a/backend/app/glossary/models.py
+++ b/backend/app/glossary/models.py
@@ -25,13 +25,13 @@ class Glossary(Base):
         default=ProcessingStatuses.IN_PROCESS
     )
     upload_time: Mapped[datetime] = mapped_column(default=datetime.now)
+    created_by: Mapped[int] = mapped_column(ForeignKey("user.id"))
 
     records: Mapped[list["GlossaryRecord"]] = relationship(
         back_populates="glossary",
         cascade="all, delete-orphan",
         order_by="GlossaryRecord.id",
     )
-    user_id: Mapped[int] = mapped_column(ForeignKey("user.id"))
     user: Mapped["User"] = relationship(back_populates="glossaries")
     documents = relationship(
         "Document", secondary="glossary_to_document", back_populates="glossaries"
@@ -45,13 +45,14 @@ class GlossaryRecord(Base):
     created_at: Mapped[datetime] = mapped_column(default=datetime.now)
     updated_at: Mapped[datetime] = mapped_column(default=datetime.now)
 
-    author: Mapped[str] = mapped_column(nullable=True)
     comment: Mapped[str] = mapped_column(nullable=True)
     source: Mapped[str] = mapped_column()
     target: Mapped[str] = mapped_column()
+    created_by: Mapped[int] = mapped_column(ForeignKey("user.id"))
 
     glossary_id: Mapped[int] = mapped_column(ForeignKey("glossary.id"))
     glossary: Mapped["Glossary"] = relationship(back_populates="records")
+    user: Mapped["User"] = relationship()
 
 
 class GlossaryToDocument(Base):

--- a/backend/app/glossary/query.py
+++ b/backend/app/glossary/query.py
@@ -63,7 +63,7 @@ class GlossaryQuery:
         processing_status: str = ProcessingStatuses.IN_PROCESS,
     ) -> Glossary:
         glossary = Glossary(
-            user_id=user_id,
+            created_by=user_id,
             processing_status=processing_status,
             **glossary.model_dump(),
         )
@@ -73,11 +73,13 @@ class GlossaryQuery:
 
     def create_glossary_record(
         self,
+        user_id: int,
         record: GlossaryRecordCreate,
         glossary_id: int,
     ) -> GlossaryRecord:
         glossary_record = GlossaryRecord(
             glossary_id=glossary_id,
+            created_by=user_id,
             **record.model_dump(),
         )
         self.db.add(glossary_record)

--- a/backend/app/glossary/schema.py
+++ b/backend/app/glossary/schema.py
@@ -18,13 +18,13 @@ class GlossaryScheme(BaseModel):
 class GlossaryResponse(IdentifiedTimestampedModel):
     processing_status: str
     upload_time: datetime.datetime
-    user_id: int
+    created_by: int
     name: str
     model_config = ConfigDict(from_attributes=True)
 
 
 class GlossaryRecordSchema(IdentifiedTimestampedModel):
-    author: str
+    created_by: int
     comment: Optional[str]
     source: str
     target: str
@@ -34,7 +34,6 @@ class GlossaryRecordSchema(IdentifiedTimestampedModel):
 
 
 class GlossaryRecordCreate(BaseModel):
-    author: str
     comment: Optional[str]
     source: str
     target: str
@@ -43,7 +42,6 @@ class GlossaryRecordCreate(BaseModel):
 
 
 class GlossaryRecordUpdate(BaseModel):
-    author: str
     comment: Optional[str]
     source: str
     target: str

--- a/backend/app/glossary/tasks.py
+++ b/backend/app/glossary/tasks.py
@@ -25,19 +25,19 @@ class GlossaryRowRecord:
         return cls(comment, created_at, author, updated_at, source, target)
 
 
-def create_glossary_from_file_tasks(sheet, db: Session, glossary_id: int):
-    record_for_save = extract_from_xlsx(sheet, glossary_id)
+def create_glossary_from_file_tasks(user_id: int, sheet, db: Session, glossary_id: int):
+    record_for_save = extract_from_xlsx(user_id, sheet, glossary_id)
     bulk_save_glossaries_update_processing_status(
         db=db, record_for_save=record_for_save, glossary_id=glossary_id
     )
 
 
-def extract_from_xlsx(sheet, glossary_id) -> list[GlossaryRecord]:
+def extract_from_xlsx(user_id: int, sheet, glossary_id: int) -> list[GlossaryRecord]:
     record_for_save = []
     for cells in sheet.iter_rows(min_row=2, values_only=True):
         parsed_record = GlossaryRowRecord.from_tuple(cells)
         record = GlossaryRecord(
-            author=parsed_record.author,
+            created_by=user_id,
             created_at=parsed_record.created_at,
             updated_at=parsed_record.updated_at,
             comment=parsed_record.comment,


### PR DESCRIPTION
- Remove useless author field coming from XLSX document.
- Rename unclear `user_id` field in glossary to `created_by` which is way more obvious.